### PR TITLE
Documentation location for onAuthStateChanged

### DIFF
--- a/appengine/standard/firebase/firenotes/frontend/main.js
+++ b/appengine/standard/firebase/firenotes/frontend/main.js
@@ -66,9 +66,8 @@ $(function(){
         $('#logged-out').show();
 
       }
-    // [END gae_python_state_change]
-
     });
+    // [END gae_python_state_change]
 
   }
 


### PR DESCRIPTION
Changes the document location to not cut off the final curly bracket and parenthesis which is required to get the script to properly run.